### PR TITLE
Update Activeresource

### DIFF
--- a/freshdesk-api.gemspec
+++ b/freshdesk-api.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'http_logger'
   spec.add_development_dependency 'rubocop'
 
-  spec.add_dependency 'activeresource', '~> 5.1.1'
+  spec.add_dependency 'activeresource', '~> 6.0'
 end


### PR DESCRIPTION
`DEPRECATION WARNING: URI.parser is deprecated and will be removed in Rails 7.0. Use `URI::DEFAULT_PARSER` instead.`