### PR TITLE
update activemodel

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 3.2
 
 Metrics/LineLength:
   Max: 120

--- a/freshdesk-api.gemspec
+++ b/freshdesk-api.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 3.2.0'
+
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
@@ -38,4 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
 
   spec.add_dependency 'activeresource'
+  spec.add_dependency 'activemodel', '~> 8.0'
 end

--- a/freshdesk-api.gemspec
+++ b/freshdesk-api.gemspec
@@ -40,5 +40,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
 
   spec.add_dependency 'activeresource'
-  spec.add_dependency 'activemodel', '~> 8.0'
 end

--- a/lib/ext/active_resource/connection.rb
+++ b/lib/ext/active_resource/connection.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/benchmark'
-require 'active_support/core_ext/uri'
 require 'active_support/core_ext/object/inclusion'
 require 'net/https'
 require 'date'

--- a/lib/freshdesk/api/version.rb
+++ b/lib/freshdesk/api/version.rb
@@ -2,6 +2,6 @@
 
 module Freshdesk
   module Api
-    VERSION = '0.1.4'
+    VERSION = '0.1.5'
   end
 end


### PR DESCRIPTION
```DEPRECATION WARNING: `active_support/core_ext/uri` is deprecated and will be removed in Rails 7.1. (called from <top (required)> at /Users/timolohmann/.rbenv/versions/3.3.7/lib/ruby/gems/3.3.0/bundler/gems/freshdesk-api-cb8a16a676c8/lib/ext/active_resource/connection.rb:4)```